### PR TITLE
Add http request route integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /target
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>

--- a/src/main/java/org/apache/camel/examples/controller/HttpRequestController.java
+++ b/src/main/java/org/apache/camel/examples/controller/HttpRequestController.java
@@ -2,6 +2,7 @@ package org.apache.camel.examples.controller;
 
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.examples.model.HttpRequestBean;
+import org.apache.camel.examples.model.HttpResponseBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,8 +19,10 @@ public class HttpRequestController {
     private ProducerTemplate producerTemplate;
     
     @PostMapping("/request")
-    public ResponseEntity<String> sendHttpRequest(@RequestBody HttpRequestBean requestBean) {
-        String response = producerTemplate.requestBody("direct:httpRequest", requestBean, String.class);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<HttpResponseBean> sendHttpRequest(@RequestBody HttpRequestBean requestBean) {
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", requestBean, HttpResponseBean.class);
+        
+        // 根据HTTP响应状态码设置Spring响应状态
+        return ResponseEntity.status(response.getStatusCode()).body(response);
     }
 }

--- a/src/main/java/org/apache/camel/examples/model/HttpRequestBean.java
+++ b/src/main/java/org/apache/camel/examples/model/HttpRequestBean.java
@@ -3,6 +3,7 @@ package org.apache.camel.examples.model;
 import lombok.Data;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.HashMap;
 
 @Data
@@ -14,18 +15,12 @@ public class HttpRequestBean {
     private Map<String, String> queryParams = new HashMap<>();
     
     public String buildFullUrl() {
-        if (queryParams.isEmpty()) {
-            return url;
-        }
-        
-        StringBuilder fullUrl = new StringBuilder(url);
-        fullUrl.append("?");
-        
-        queryParams.forEach((key, value) -> fullUrl.append(key)
-            .append("=")
-            .append(value)
-            .append("&"));
-        
-        return fullUrl.substring(0, fullUrl.length() - 1);
+        // 不是http param, 是camel内置参数, false时非200不再抛出异常
+        queryParams.put("throwExceptionOnFailure", "false");
+
+        return queryParams.entrySet()
+            .stream()
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining("&", url + "?", ""));
     }
 }

--- a/src/main/java/org/apache/camel/examples/model/HttpResponseBean.java
+++ b/src/main/java/org/apache/camel/examples/model/HttpResponseBean.java
@@ -2,34 +2,14 @@ package org.apache.camel.examples.model;
 
 import lombok.Data;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 
 import java.util.Map;
 import java.util.HashMap;
 
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 public class HttpResponseBean {
     private int statusCode;
-    private String statusText;
     private Map<String, Object> headers = new HashMap<>();
     private String body;
-    private String contentType;
-    
-    public static HttpResponseBean success(String body) {
-        HttpResponseBean response = new HttpResponseBean();
-        response.setStatusCode(200);
-        response.setStatusText("OK");
-        response.setBody(body);
-        return response;
-    }
-    
-    public static HttpResponseBean error(int statusCode, String statusText, String body) {
-        HttpResponseBean response = new HttpResponseBean();
-        response.setStatusCode(statusCode);
-        response.setStatusText(statusText);
-        response.setBody(body);
-        return response;
-    }
 }

--- a/src/main/java/org/apache/camel/examples/model/HttpResponseBean.java
+++ b/src/main/java/org/apache/camel/examples/model/HttpResponseBean.java
@@ -1,0 +1,35 @@
+package org.apache.camel.examples.model;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+import java.util.HashMap;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HttpResponseBean {
+    private int statusCode;
+    private String statusText;
+    private Map<String, Object> headers = new HashMap<>();
+    private String body;
+    private String contentType;
+    
+    public static HttpResponseBean success(String body) {
+        HttpResponseBean response = new HttpResponseBean();
+        response.setStatusCode(200);
+        response.setStatusText("OK");
+        response.setBody(body);
+        return response;
+    }
+    
+    public static HttpResponseBean error(int statusCode, String statusText, String body) {
+        HttpResponseBean response = new HttpResponseBean();
+        response.setStatusCode(statusCode);
+        response.setStatusText(statusText);
+        response.setBody(body);
+        return response;
+    }
+}

--- a/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
+++ b/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
@@ -34,16 +34,11 @@ public class HttpRequestRoute extends RouteBuilder {
     
     private void processHttpRequest(Exchange exchange) {
         HttpRequestBean request = exchange.getIn().getBody(HttpRequestBean.class);
-        
+
         exchange.getIn().setHeader(Exchange.HTTP_METHOD, request.getMethod());
-        
-        // 构建完整的URL并添加throwExceptionOnFailure=false参数
-        String fullUrl = request.buildFullUrl();
-        String httpEndpoint = fullUrl + (fullUrl.contains("?") ? "&" : "?") + "throwExceptionOnFailure=false";
-        exchange.getIn().setHeader("HTTP_ENDPOINT", httpEndpoint);
-        
+        exchange.getIn().setHeader("HTTP_ENDPOINT", request.buildFullUrl());
         request.getHeaders().forEach((k, v) -> exchange.getIn().setHeader(k, v));
-        
+
         String body = request.getBody();
         exchange.getIn().setBody(body != null && !body.trim().isEmpty() ? body : "");
     }

--- a/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
+++ b/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
@@ -36,7 +36,12 @@ public class HttpRequestRoute extends RouteBuilder {
         HttpRequestBean request = exchange.getIn().getBody(HttpRequestBean.class);
         
         exchange.getIn().setHeader(Exchange.HTTP_METHOD, request.getMethod());
-        exchange.getIn().setHeader("HTTP_ENDPOINT", request.buildFullUrl());
+        
+        // 构建完整的URL并添加throwExceptionOnFailure=false参数
+        String fullUrl = request.buildFullUrl();
+        String httpEndpoint = fullUrl + (fullUrl.contains("?") ? "&" : "?") + "throwExceptionOnFailure=false";
+        exchange.getIn().setHeader("HTTP_ENDPOINT", httpEndpoint);
+        
         request.getHeaders().forEach((k, v) -> exchange.getIn().setHeader(k, v));
         
         String body = request.getBody();

--- a/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
+++ b/src/main/java/org/apache/camel/examples/route/HttpRequestRoute.java
@@ -4,6 +4,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 import org.apache.camel.examples.model.HttpRequestBean;
+import org.apache.camel.examples.model.HttpResponseBean;
+
+import java.util.Map;
+import java.util.HashMap;
 
 @Component
 public class HttpRequestRoute extends RouteBuilder {
@@ -31,9 +35,69 @@ public class HttpRequestRoute extends RouteBuilder {
     }
     
     private void processHttpResponse(Exchange exchange) {
+        // 获取响应信息
         Integer statusCode = exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
-        if (statusCode != null) {
-            exchange.getIn().setHeader("RESPONSE_STATUS_CODE", statusCode);
+        String responseBody = exchange.getIn().getBody(String.class);
+        
+        // 创建响应对象
+        HttpResponseBean response = new HttpResponseBean();
+        response.setStatusCode(statusCode != null ? statusCode : 200);
+        response.setStatusText(getStatusText(response.getStatusCode()));
+        response.setBody(responseBody);
+        
+        // 获取响应头
+        Map<String, Object> responseHeaders = new HashMap<>();
+        Map<String, Object> exchangeHeaders = exchange.getIn().getHeaders();
+        
+        // 过滤并收集HTTP响应头
+        exchangeHeaders.entrySet().stream()
+            .filter(entry -> isHttpResponseHeader(entry.getKey()))
+            .forEach(entry -> responseHeaders.put(entry.getKey(), entry.getValue()));
+        
+        response.setHeaders(responseHeaders);
+        
+        // 设置Content-Type
+        Object contentType = exchange.getIn().getHeader("Content-Type");
+        if (contentType != null) {
+            response.setContentType(contentType.toString());
         }
+        
+        // 将封装的响应对象设置为消息体
+        exchange.getIn().setBody(response);
+    }
+    
+    private boolean isHttpResponseHeader(String headerName) {
+        return headerName != null && (
+            headerName.startsWith("Content-") ||
+            headerName.startsWith("Cache-") ||
+            headerName.startsWith("X-") ||
+            headerName.equals("Date") ||
+            headerName.equals("Server") ||
+            headerName.equals("Location") ||
+            headerName.equals("Set-Cookie") ||
+            headerName.equals("Transfer-Encoding") ||
+            headerName.equals("Connection") ||
+            headerName.equals("Vary") ||
+            headerName.equals("ETag") ||
+            headerName.equals("Last-Modified")
+        );
+    }
+    
+    private String getStatusText(int statusCode) {
+        return switch (statusCode) {
+            case 200 -> "OK";
+            case 201 -> "Created";
+            case 204 -> "No Content";
+            case 301 -> "Moved Permanently";
+            case 302 -> "Found";
+            case 400 -> "Bad Request";
+            case 401 -> "Unauthorized";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 500 -> "Internal Server Error";
+            case 502 -> "Bad Gateway";
+            case 503 -> "Service Unavailable";
+            default -> "Unknown";
+        };
     }
 }

--- a/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
+++ b/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
@@ -66,17 +66,12 @@ class HttpRequestRouteIntegrationTest {
         headers.put("accept", "text/plain");
         request.setHeaders(headers);
 
-        try {
-            HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
-            
-            // 如果没有抛出异常，验证错误状态码被正确封装
-            assertThat(response).isNotNull();
-            assertThat(response.getStatusCode()).isGreaterThanOrEqualTo(400);
-        } catch (Exception e) {
-            // 验证异常是HTTP相关的错误
-            assertThat(e.getCause()).isNotNull();
-            assertThat(e.getCause().getClass().getSimpleName()).contains("Http");
-        }
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
+        
+        // 验证错误状态码被正确透传给上游
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
     }
 
     @Test

--- a/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
+++ b/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
@@ -1,0 +1,196 @@
+package org.apache.camel.examples.route;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.examples.model.HttpRequestBean;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class HttpRequestRouteIntegrationTest {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Autowired
+    private ProducerTemplate producerTemplate;
+
+    @Test
+    void shouldProcessHttpRequestWithHeaders() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("POST");
+        request.setUrl("http://httpbin.org/post");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Custom-Header", "test-value");
+        headers.put("Authorization", "Bearer test-token");
+        request.setHeaders(headers);
+        
+        request.setBody("{\"message\":\"test\"}");
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        assertThat(response).contains("test-value");
+    }
+
+    @Test
+    void shouldHandleGetRequestWithoutBody() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/get");
+        request.setHeaders(new HashMap<>());
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        assertThat(response).contains("get");
+    }
+
+    @Test
+    void shouldTransparentlyPassErrorStatusCodeToUpstream() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/status/400");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "text/plain");
+        request.setHeaders(headers);
+
+        try {
+            String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+            
+            // httpbin.org/status/400 会返回400状态码
+            // Camel会抛出HttpOperationFailedException，这是预期行为
+            assertThat(response).isNotNull();
+        } catch (Exception e) {
+            // 验证异常是HTTP相关的错误
+            assertThat(e.getCause()).isNotNull();
+            assertThat(e.getCause().getClass().getSimpleName()).contains("Http");
+        }
+    }
+
+    @Test
+    void shouldTransparentlyPassResponseHeadersToUpstream() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/response-headers");
+        
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("X-Test-Header", "test-header-value");
+        queryParams.put("Content-Type", "application/json");
+        request.setQueryParams(queryParams);
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/json");
+        request.setHeaders(headers);
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        assertThat(response).contains("X-Test-Header");
+        assertThat(response).contains("test-header-value");
+    }
+
+    @Test
+    void shouldTransparentlyPassResponseBodyToUpstream() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("POST");
+        request.setUrl("http://httpbin.org/post");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/json");
+        headers.put("Content-Type", "application/json");
+        request.setHeaders(headers);
+        
+        String requestBody = "{\"message\":\"response-body-test\",\"timestamp\":\"2024-01-01\"}";
+        request.setBody(requestBody);
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        assertThat(response).contains("response-body-test");
+        assertThat(response).contains("2024-01-01");
+        assertThat(response).contains("json");
+    }
+
+    @Test
+    void shouldTransparentlyPassRequestHeadersToDownstream() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/headers");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Custom-Downstream-Header", "downstream-test-value");
+        headers.put("User-Agent", "Camel-Http-Test/1.0");
+        headers.put("Authorization", "Bearer downstream-token");
+        request.setHeaders(headers);
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        // httpbin.org/headers 会返回请求中的所有header
+        assertThat(response).contains("X-Custom-Downstream-Header");
+        assertThat(response).contains("downstream-test-value");
+        assertThat(response).contains("Camel-Http-Test/1.0");
+        assertThat(response).contains("Bearer downstream-token");
+    }
+
+    @Test
+    void shouldTransparentlyPassRequestBodyToDownstream() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("POST");
+        request.setUrl("http://httpbin.org/post");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        headers.put("accept", "application/json");
+        request.setHeaders(headers);
+        
+        String requestBody = "{\"operation\":\"request-body-test\",\"data\":{\"field1\":\"value1\",\"field2\":123}}";
+        request.setBody(requestBody);
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        // httpbin.org/post 会在响应中回显请求体
+        assertThat(response).contains("request-body-test");
+        assertThat(response).contains("field1");
+        assertThat(response).contains("value1");
+        assertThat(response).contains("field2");
+        assertThat(response).contains("123");
+    }
+
+    @Test
+    void shouldHandleComplexRequestWithMultipleQueryParams() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/get");
+        
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("param1", "value1");
+        queryParams.put("param2", "chinese-param");
+        queryParams.put("param3", "special@characters");
+        request.setQueryParams(queryParams);
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/json");
+        request.setHeaders(headers);
+
+        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        
+        assertThat(response).isNotNull();
+        assertThat(response).contains("param1");
+        assertThat(response).contains("value1");
+        assertThat(response).contains("param2");
+        assertThat(response).contains("param3");
+    }
+}

--- a/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
+++ b/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
@@ -3,6 +3,7 @@ package org.apache.camel.examples.route;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.examples.model.HttpRequestBean;
+import org.apache.camel.examples.model.HttpResponseBean;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,10 +37,13 @@ class HttpRequestRouteIntegrationTest {
         
         request.setBody("{\"message\":\"test\"}");
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
-        assertThat(response).contains("test-value");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("test-value");
     }
 
     @Test
@@ -49,10 +53,13 @@ class HttpRequestRouteIntegrationTest {
         request.setUrl("http://httpbin.org/get");
         request.setHeaders(new HashMap<>());
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
-        assertThat(response).contains("get");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("get");
     }
 
     @Test
@@ -66,11 +73,11 @@ class HttpRequestRouteIntegrationTest {
         request.setHeaders(headers);
 
         try {
-            String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+            HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
             
-            // httpbin.org/status/400 会返回400状态码
-            // Camel会抛出HttpOperationFailedException，这是预期行为
+            // 如果没有抛出异常，验证错误状态码被正确封装
             assertThat(response).isNotNull();
+            assertThat(response.getStatusCode()).isGreaterThanOrEqualTo(400);
         } catch (Exception e) {
             // 验证异常是HTTP相关的错误
             assertThat(e.getCause()).isNotNull();
@@ -93,11 +100,14 @@ class HttpRequestRouteIntegrationTest {
         headers.put("accept", "application/json");
         request.setHeaders(headers);
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
-        assertThat(response).contains("X-Test-Header");
-        assertThat(response).contains("test-header-value");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("X-Test-Header");
+        assertThat(response.getBody()).contains("test-header-value");
+        assertThat(response.getHeaders()).isNotNull();
     }
 
     @Test
@@ -114,12 +124,16 @@ class HttpRequestRouteIntegrationTest {
         String requestBody = "{\"message\":\"response-body-test\",\"timestamp\":\"2024-01-01\"}";
         request.setBody(requestBody);
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
-        assertThat(response).contains("response-body-test");
-        assertThat(response).contains("2024-01-01");
-        assertThat(response).contains("json");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("response-body-test");
+        assertThat(response.getBody()).contains("2024-01-01");
+        assertThat(response.getBody()).contains("json");
+        assertThat(response.getHeaders()).isNotNull();
     }
 
     @Test
@@ -134,14 +148,17 @@ class HttpRequestRouteIntegrationTest {
         headers.put("Authorization", "Bearer downstream-token");
         request.setHeaders(headers);
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
         // httpbin.org/headers 会返回请求中的所有header
-        assertThat(response).contains("X-Custom-Downstream-Header");
-        assertThat(response).contains("downstream-test-value");
-        assertThat(response).contains("Camel-Http-Test/1.0");
-        assertThat(response).contains("Bearer downstream-token");
+        assertThat(response.getBody()).contains("X-Custom-Downstream-Header");
+        assertThat(response.getBody()).contains("downstream-test-value");
+        assertThat(response.getBody()).contains("Camel-Http-Test/1.0");
+        assertThat(response.getBody()).contains("Bearer downstream-token");
+        assertThat(response.getHeaders()).isNotNull();
     }
 
     @Test
@@ -158,15 +175,19 @@ class HttpRequestRouteIntegrationTest {
         String requestBody = "{\"operation\":\"request-body-test\",\"data\":{\"field1\":\"value1\",\"field2\":123}}";
         request.setBody(requestBody);
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        assertThat(response.getBody()).isNotNull();
         // httpbin.org/post 会在响应中回显请求体
-        assertThat(response).contains("request-body-test");
-        assertThat(response).contains("field1");
-        assertThat(response).contains("value1");
-        assertThat(response).contains("field2");
-        assertThat(response).contains("123");
+        assertThat(response.getBody()).contains("request-body-test");
+        assertThat(response.getBody()).contains("field1");
+        assertThat(response.getBody()).contains("value1");
+        assertThat(response.getBody()).contains("field2");
+        assertThat(response.getBody()).contains("123");
+        assertThat(response.getHeaders()).isNotNull();
     }
 
     @Test
@@ -185,12 +206,47 @@ class HttpRequestRouteIntegrationTest {
         headers.put("accept", "application/json");
         request.setHeaders(headers);
 
-        String response = producerTemplate.requestBody("direct:httpRequest", request, String.class);
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
         
         assertThat(response).isNotNull();
-        assertThat(response).contains("param1");
-        assertThat(response).contains("value1");
-        assertThat(response).contains("param2");
-        assertThat(response).contains("param3");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("param1");
+        assertThat(response.getBody()).contains("value1");
+        assertThat(response.getBody()).contains("param2");
+        assertThat(response.getBody()).contains("param3");
+        assertThat(response.getHeaders()).isNotNull();
+    }
+
+    @Test
+    void shouldProvideCompleteHttpResponseObject() {
+        HttpRequestBean request = new HttpRequestBean();
+        request.setMethod("GET");
+        request.setUrl("http://httpbin.org/get");
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/json");
+        headers.put("User-Agent", "Test-Agent");
+        request.setHeaders(headers);
+
+        HttpResponseBean response = producerTemplate.requestBody("direct:httpRequest", request, HttpResponseBean.class);
+
+        // 验证完整的响应对象结构
+        assertThat(response).isNotNull();
+        
+        // 验证状态码和状态文本
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getStatusText()).isEqualTo("OK");
+        
+        // 验证响应体
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isNotEmpty();
+        
+        // 验证响应头
+        assertThat(response.getHeaders()).isNotNull();
+        
+        // 验证Content-Type
+        assertThat(response.getContentType()).isNotNull();
     }
 }

--- a/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
+++ b/src/test/java/org/apache/camel/examples/route/HttpRequestRouteIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.apache.camel.examples.route;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.examples.model.HttpRequestBean;
 import org.apache.camel.examples.model.HttpResponseBean;
@@ -17,9 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ActiveProfiles("test")
 class HttpRequestRouteIntegrationTest {
-
-    @Autowired
-    private CamelContext camelContext;
 
     @Autowired
     private ProducerTemplate producerTemplate;
@@ -41,7 +37,6 @@ class HttpRequestRouteIntegrationTest {
         
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).contains("test-value");
     }
@@ -57,7 +52,6 @@ class HttpRequestRouteIntegrationTest {
         
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).contains("get");
     }
@@ -128,7 +122,6 @@ class HttpRequestRouteIntegrationTest {
         
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).contains("response-body-test");
         assertThat(response.getBody()).contains("2024-01-01");
@@ -179,7 +172,6 @@ class HttpRequestRouteIntegrationTest {
         
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         assertThat(response.getBody()).isNotNull();
         // httpbin.org/post 会在响应中回显请求体
         assertThat(response.getBody()).contains("request-body-test");
@@ -210,7 +202,6 @@ class HttpRequestRouteIntegrationTest {
         
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).contains("param1");
         assertThat(response.getBody()).contains("value1");
@@ -237,7 +228,6 @@ class HttpRequestRouteIntegrationTest {
         
         // 验证状态码和状态文本
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getStatusText()).isEqualTo("OK");
         
         // 验证响应体
         assertThat(response.getBody()).isNotNull();
@@ -245,8 +235,5 @@ class HttpRequestRouteIntegrationTest {
         
         // 验证响应头
         assertThat(response.getHeaders()).isNotNull();
-        
-        // 验证Content-Type
-        assertThat(response.getContentType()).isNotNull();
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  main:
+    web-application-type: none
+
+logging:
+  level:
+    org.apache.camel: DEBUG
+    org.springframework: INFO


### PR DESCRIPTION
HttpRequestRouteIntegrationTest.java 在这类中增加更多测试用例, 请求也是直接发到@http://httpbin.org, 我想到以下case
1. curl -X GET "https://httpbin.org/status/400" -H  "accept: text/plain" 会将响应code透传给上游
2. curl -X GET "https://httpbin.org/basic-auth/user/password" -H  "accept: application/json" 会将响应header透传给上游
3. curl -X POST "https://httpbin.org/post" -H  "accept: application/json" 会将响应体透传给上游

这些是透传给上游的, 再写几个透传给下游的, 比如将header透传给下游, 将body透传给下游的

---
<a href="https://cursor.com/background-agent?bcId=bc-b68e1576-30e5-4103-bd57-56f583b500be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b68e1576-30e5-4103-bd57-56f583b500be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

